### PR TITLE
Release 0.9.8 — documentation honesty pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 > See [LICENSE](https://github.com/mgillr/crdt-merge/blob/main/LICENSE) for details.
 
 
+## [0.9.8] - 2026-04-18 — Documentation Honesty Pass
+
+No runtime changes. Tightens documentation wording against prior art so downstream claims match the paper's more careful phrasing. The published arXiv paper (`paper/CRDT_Merge_ArXiv.tex`) is unchanged; this release only updates README, CHANGELOG, and `docs/`.
+
+### Changed
+- Byzantine-tolerance claim reframed across README, E4 docs, CHANGELOG, security guide, and federated-model-merging guide: **34% is an empirical measurement under the SLT harness**, not a PBFT-style theoretical bound. SLT is a Byzantine-detection protocol; it is not a consensus protocol and is not comparable to PBFT's ≤n/3 consensus safety.
+- Product-lattice wording clarified (README, `docs/e4/E4-MASTER-ARCHITECTURE.md` §II): the product-of-join-semilattices construction is standard algebra (Birkhoff 1940); E4's contribution is the inclusion of Trust as a lattice dimension, not the product construction itself.
+- `docs/e4/E4-MASTER-ARCHITECTURE.md` §VI renamed from "Entanglement Proof" to "Dependency Analysis (not a formal proof)". Content was a coupling / dependency argument; the heading now reflects that.
+- `docs/guides/security-guide.md`: "Statistical Lattice Trust" → "Symbiotic Lattice Trust" (acronym unification).
+- 156/156 CRDT axiom trials re-labelled with method context (commutativity / associativity / idempotency × 26 strategies × both opt model sizes on real weight tensors) in CHANGELOG, `docs/ARCHITECTURE_MAP.md`, `docs/e4/README.md`, and `docs/e4/E4-COMPUTATIONAL-EVIDENCE.md`.
+
+### Fixed (roadmap drift)
+- `docs/e4/E4-CHANGELOG.md` Future Work: removed "Formal TLA+ specification of convergence" -- it shipped in 0.9.5 (resilience subsystem, 5/5 properties / 700 states).
+- `docs/CRDT_ARCHITECTURE.md` §11 Future Work: 11.3 (Conflict Resolution Policies) and 11.4 (Streaming Merge) marked **SHIPPED** -- `MergeStrategy`/`MergeSchema` (v0.3.0) and `merge_stream`/`merge_sorted_stream` (v0.3.0) are public API today. Added §11.6 forward-reference to v0.9.9 alignment bounds.
+
+### Compatibility
+- Zero breaking changes. No code paths touched. Test suite pass count unchanged.
+
+
 ## [0.9.7] - 2026-04-17 — Patch Release
 
 Bundles fixes and test-coverage additions that landed after the v0.9.6 tag. Contains the E4 hardening work from v0.9.6 (see below) plus the changes listed here.
@@ -85,7 +104,7 @@ Patents: UK Application No. GB 2607132.4, GB2608127.3
 - Trust-bound Merkle verification (256-ary, depth 4 at 1B leaves, perfect 0.500 bit diffusion)
 - Causal trust clocks -- 2.93M ops/s vector clock with trust dimension binding
 - Adaptive verification controller -- scales verification depth by trust level (97K-109K ops/s)
-- Symbiotic Lattice Trust (SLT) Byzantine protocol -- 34% fault tolerance, no coordinator
+- Symbiotic Lattice Trust (SLT) Byzantine-detection protocol -- empirical 34% adversarial-participant tolerance under the evaluated harness (not PBFT consensus), no coordinator
 - Trust-weighted conflict resolution strategies (LWW, averaging, acceptance gating)
 - Dual-hash compatibility mode for incremental migration from pre-E4 peers
 - Integration bridges: gossip (trust metadata in messages), streaming (per-chunk validation), agentic (trust-weighted memory sync)
@@ -93,7 +112,7 @@ Patents: UK Application No. GB 2607132.4, GB2608127.3
 - Trust homeostasis -- conserved-budget normalisation prevents trust inflation
 - Circuit breaker -- sigma-based anomaly detection with automatic cooldown
 - End-to-end federation pipeline validated at 9.69ms for 10-node cluster with 2 Byzantine actors
-- Large-scale validation: facebook/opt-1.3b and facebook/opt-6.7b (6.7B parameters) -- 156/156 PASS
+- Large-scale validation on facebook/opt-1.3b and facebook/opt-6.7b (6.7B parameters): 156/156 CRDT axiom trials pass (commutativity / associativity / idempotency across all 26 strategies on real weight tensors)
 - Agent memory trust synchronisation (3 agents, 4 models, full convergence proven)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ E4 eliminates this separation. Trust, data, causal clock, and Merkle hash form a
 E4State = Data x Trust x Clock x Hash
 ```
 
-Each dimension is a join-semilattice. The product of join-semilattices is a join-semilattice. Convergence is algebraic -- not a property that needs to be tested, but one that is inherited from the structure.
+Each dimension is a join-semilattice. The product of join-semilattices is a join-semilattice -- a standard result (Birkhoff 1940). The E4 contribution is **including Trust as a lattice dimension** alongside Data and letting it propagate through the same delta pipeline, not reinventing the product construction. Convergence of the unified system is then inherited from that standard result, so it does not need a separate proof.
 
 ### Cryptographic hardening (v0.9.6)
 
@@ -112,7 +112,7 @@ No existing literature combines all six. Delta-state CRDTs handle P1-P2 (Almeida
 
 The Symbiotic Lattice Trust (SLT) protocol replaces BFT consensus with lattice-native Byzantine detection. Each peer maintains a five-dimensional trust vector (integrity, causality, consistency, gossip, model) as per-dimension GCounters with homeostatic budget normalisation. Malicious behaviour triggers monotonic trust decay that propagates as CRDT deltas -- every honest peer converges on the same trust state without coordination.
 
-SLT's threat model differs from classical BFT (Castro and Liskov, 1999). Classical BFT guarantees safety below n/3 through voting rounds. SLT operates without voting -- Byzantine detection emerges from trust score convergence across the lattice. The 34% tolerance threshold was measured empirically with actively Byzantine peers performing data injection, trust inflation, and selective withholding. The guarantee is CRDT convergence of trust state among honest peers, which then gates data application. End-to-end federation across 10 nodes with 2 Byzantine peers: 9.69ms.
+SLT is not a consensus protocol and does not claim PBFT equivalence. Classical BFT (Castro and Liskov, 1999) guarantees consensus safety below n/3 through voting rounds; SLT has no voting. Instead, Byzantine detection emerges from trust score convergence across the lattice, and the trust state gates data application. Under our evaluated harness -- 10 nodes, actively Byzantine peers performing data injection, trust inflation, and selective withholding -- honest peers continued to converge on identical trust state with up to 34% adversarial participation. This is an empirical measurement of the specific harness, not a theoretical bound. End-to-end federation across 10 nodes with 2 Byzantine peers: 9.69ms.
 
 ### Delta encoding at scale
 
@@ -238,7 +238,7 @@ Zero required dependencies. Python 3.9-3.12. Linux, macOS, Windows.
 |--------|--------|---------|
 | CRDT axiom compliance | 78/78 | All 26 strategies, all 3 laws |
 | Test suite | 6,179 passing, 0 failures | Core + E4 + resilience |
-| Byzantine fault tolerance | 34% | SLT protocol, empirically measured |
+| Adversarial-participant tolerance | 34% | SLT harness; honest peers still converge (not PBFT consensus) |
 | Proof-carrying operation wire size | 128 bytes | Fixed cost per operation |
 | Causal clock throughput | 2.93M ops/s | E4 causal clock subsystem |
 | End-to-end federation | 9.69ms | 10 nodes, 2 actively Byzantine |

--- a/crdt_merge/__init__.py
+++ b/crdt_merge/__init__.py
@@ -56,7 +56,7 @@ Usage:
     merged = merge_datasets("user/dataset-a", "user/dataset-b", key="id")
 """
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"
 
 __all__ = [
     # Core CRDT types

--- a/docs/ARCHITECTURE_MAP.md
+++ b/docs/ARCHITECTURE_MAP.md
@@ -256,7 +256,7 @@ crdt-merge is a **7-layer architecture** with orthogonal Accelerator and CLI sub
 
 **Dependencies**: Layers 1-6 (composes with all existing subsystems)
 
-**Validation**: 78/78 CRDT axioms, 156/156 large-model tests, 34% Byzantine fault tolerance, 328 computational proofs
+**Validation**: 78/78 CRDT axioms (26 strategies × 3 laws), 156/156 CRDT axiom trials on real weight tensors (facebook/opt-1.3b + opt-6.7b), 34% adversarial-participant tolerance under the SLT harness (not PBFT consensus), 328 computational proofs
 
 ---
 

--- a/docs/CRDT_ARCHITECTURE.md
+++ b/docs/CRDT_ARCHITECTURE.md
@@ -1547,20 +1547,23 @@ class RemoteBackedCRDTState(CRDTMergeState):
         return super().add(model_id, tensors, **kwargs)
 ```
 
-### 11.3 Conflict Resolution Policies
+### 11.3 Conflict Resolution Policies — **SHIPPED**
 
-While the current architecture uses add-wins semantics, future work
-could support configurable conflict resolution:
+Configurable conflict resolution is implemented today via `MergeStrategy`
+and `MergeSchema` (see `crdt_merge/strategies.py`). Built-in strategies
+include `LWW`, `MaxWins`, `MinWins`, `UnionSet`, `Priority`, `Concat`,
+`LongestWins`, and `Custom` (user-defined). Per-column selection is
+supported via `MergeSchema`. This section is retained for historical
+context; see the strategies module for the current API.
 
-- **Last-Writer-Wins (LWW)** — Most recent update wins
-- **Priority-Based** — Higher-priority nodes win
-- **Voting** — Majority of replicas must agree
-- **Custom** — User-defined resolution functions
+### 11.4 Streaming Merge — **SHIPPED**
 
-### 11.4 Streaming Merge
-
-For extremely large models that don't fit in memory, a streaming merge
-API would process one layer at a time:
+Streaming merge is implemented today via `merge_stream` and
+`merge_sorted_stream` (see `crdt_merge/streaming.py`). The current API
+operates on row batches for O(batch_size) memory usage; per-layer
+streaming for billion-parameter tensors is further scoped as a v0.10.x
+item. The illustrative `streaming_resolve` sketch below is retained
+for historical context.
 
 ```python
 async def streaming_resolve(self) -> AsyncIterator[Tuple[str, np.ndarray]]:
@@ -1575,6 +1578,14 @@ async def streaming_resolve(self) -> AsyncIterator[Tuple[str, np.ndarray]]:
         )
         yield layer_name, merged_layer
 ```
+
+### 11.6 Alignment Bounds (planned v0.9.9)
+
+v0.9.9 adds `crdt_merge/alignment/` -- lattice upper-element bounds
+(`L2Ball`, `SimplexBound`, `ActivationPercentileBound`) plus a
+`BoundedMerge` wrapper that projects the merged result back into a
+user-declared safe region while preserving CRDT convergence. See the
+v0.9.9 tracking plan for scope.
 
 ### 11.5 Formal Verification
 

--- a/docs/e4/E4-CHANGELOG.md
+++ b/docs/e4/E4-CHANGELOG.md
@@ -301,9 +301,12 @@ Master architecture document: [E4-MASTER-ARCHITECTURE.md](../E4-MASTER-ARCHITECT
 - Key rotation protocol (new identity not required)
 - Differential privacy for trust observations
 - GPU-accelerated Merkle tree operations
-- Formal TLA+ specification of convergence
 - Trust recovery protocol (controlled trust increase)
 - Hierarchical trust delegation
+
+### Shipped in 0.9.5 (previously listed under Future Work)
+
+- **Formal TLA+ specification of convergence** -- shipped as part of the resilience subsystem in 0.9.5 (5/5 properties verified over 700 states; see CHANGELOG [0.9.5] resilience entry).
 
 ---
 

--- a/docs/e4/E4-COMPUTATIONAL-EVIDENCE.md
+++ b/docs/e4/E4-COMPUTATIONAL-EVIDENCE.md
@@ -58,15 +58,17 @@ Proof-carrying operations (PCO) wrap each merge operation in a fixed-size proof 
 
 ---
 
-## 6. Byzantine Tolerance
+## 6. Adversarial-Participant Tolerance (SLT harness)
 
 The Symbiotic Lattice Trust (SLT) protocol detects and isolates Byzantine actors through trust distance metrics. Honest nodes naturally cluster; Byzantine nodes diverge.
 
-- **Fault tolerance**: 34% (exceeds the 33.3% BFT theoretical threshold)
+SLT is not a consensus protocol and is not being compared to PBFT's ≤n/3 safety bound -- that bound is a theoretical guarantee over binary-value consensus, while SLT is an empirical measurement of CRDT trust-state convergence under adversarial peers.
+
+- **Adversarial-participant tolerance (this harness)**: 34% -- honest peers continued to converge on identical trust state with up to 34% of peers actively Byzantine
 - **Honest node distance**: 49.5
 - **Byzantine node distance**: 165.0
 - **End-to-end pipeline**: 9.69ms (10-node federation including 2 Byzantine actors)
-- **Method**: Federation of 10 nodes, 2 configured as Byzantine (arbitrary message injection). Pipeline time measured from initial merge request to full convergence with Byzantine nodes isolated.
+- **Method**: Federation of 10 nodes, 2 configured as Byzantine (arbitrary message injection). Pipeline time measured from initial merge request to full convergence with Byzantine nodes isolated. Number is a single-configuration empirical observation, not a theoretical bound.
 
 ---
 
@@ -95,7 +97,7 @@ Delta encoding and clock operations tested at scale to verify throughput does no
 E4 trust pipeline validated end-to-end on production-scale language models.
 
 - **Models**: facebook/opt-1.3b (1.3B parameters), facebook/opt-6.7b (6.7B parameters)
-- **Result**: 156/156 PASS
+- **Result**: 156/156 CRDT axiom trials pass (commutativity / associativity / idempotency × 26 strategies × both model sizes, on real weight tensors)
 - **Method**: Full CRDT axiom verification (commutativity, associativity, idempotency) across all 26 strategies on actual model weight tensors. Each test loads real model weights, applies the merge strategy with trust scoring, and verifies algebraic law compliance.
 
 ---
@@ -120,10 +122,10 @@ Trust-weighted memory synchronisation across multiple agents using different mod
 | Merkle verification | Bit diffusion | 0.500 |
 | Clock throughput | ops/s | 2.93M |
 | PCO wire format | Envelope size | 128 bytes |
-| Byzantine tolerance | Fault threshold | 34% |
+| Adversarial-participant tolerance | SLT harness (not PBFT) | 34% |
 | Strategy validation | Trust-weighted influence | 55.9% |
 | Delta/clock scaling | ops/s at scale | 1.45M / 3.08M |
-| Large-scale models | Tests passed | 156/156 |
+| Large-scale models -- CRDT axiom trials on weight tensors | Tests passed | 156/156 |
 | Agent memory | Convergence | 3 agents, 4 models |
 | **Total proofs** | | **328** |
 | **Total test functions** | E4 + core | **6,179** |

--- a/docs/e4/E4-MASTER-ARCHITECTURE.md
+++ b/docs/e4/E4-MASTER-ARCHITECTURE.md
@@ -42,7 +42,7 @@ E4State = Data × Trust × Clock × Hash
 Join: (d₁,t₁,c₁,h₁) ⊔ (d₂,t₂,c₂,h₂) = (d₁⊔d₂, t₁⊔t₂, c₁⊔c₂, recompute_h)
 ```
 
-Data, Trust, Clock are independent join-semilattices. Hash is a dependent dimension derived from Data×Trust. The product of join-semilattices is a join-semilattice. This is the CRDT convergence proof for the unified system.
+Data, Trust, Clock are independent join-semilattices. Hash is a dependent dimension derived from Data×Trust. The product-of-join-semilattices-is-a-join-semilattice construction is standard algebra (Birkhoff 1940; any CRDT textbook). The E4 contribution is not the product construction itself but the inclusion of **Trust** as a first-class lattice dimension entangled with Data through the recursive-propagation primitive P6; that, combined with the standard product-lattice result, gives convergence of the unified system without a separate proof.
 
 ---
 
@@ -1075,7 +1075,9 @@ Output: Converged trust state
 
 ---
 
-## VI. ENTANGLEMENT PROOF
+## VI. DEPENDENCY ANALYSIS (not a formal proof)
+
+This section argues, component by component, why each part of E4 is load-bearing for the others. It is a coupling / dependency argument, not a machine-checked or mathematical proof. The formal convergence guarantee comes from the product-lattice construction in §II, not from this section.
 
 ### Why Each Component Cannot Be Removed
 

--- a/docs/e4/README.md
+++ b/docs/e4/README.md
@@ -43,12 +43,12 @@ Disable E4 if needed: `CRDT_MERGE_E4=0`
 | Subsystem | Metric | Result |
 |-----------|--------|--------|
 | CRDT axiom compliance | 26 strategies x 3 axioms | 78/78 (0.0 residual) |
-| Large-scale validation | facebook/opt-1.3b + opt-6.7b | 156/156 PASS |
+| Large-scale CRDT axiom trials on weight tensors | facebook/opt-1.3b + opt-6.7b | 156/156 PASS |
 | Trust-bound Merkle | Bit diffusion (avalanche) | 0.500 (cryptographically ideal) |
 | PCO wire format | Fixed size | 128 bytes |
 | PCO throughput | Build / Verify | 167K / 101K ops/s |
 | Causal trust clocks | Vector clock throughput | 2.93M ops/s |
-| Byzantine tolerance | Fault threshold | 34% (exceeds 33.3% BFT) |
+| Adversarial-participant tolerance | SLT harness (not PBFT) | 34% |
 | Byzantine pipeline | End-to-end (10 nodes, 2 Byzantine) | 9.69ms |
 | Trust convergence | Max divergence | 0.0 |
 | Trust convergence | Convergence time | 3.84ms |
@@ -73,7 +73,7 @@ E4 is structured as five interlocking subsystems:
 
 **Projection Delta Encoding** -- Sparse delta representation maps billion-parameter model spaces into compact trust-annotated diffs. Achieves 1.45M ops/s at 10K entries.
 
-**Symbiotic Lattice Trust (SLT)** -- Byzantine protocol achieving 34% fault tolerance. Honest nodes converge at distance 49.5 vs Byzantine distance 165.0. No coordinator, no voting rounds.
+**Symbiotic Lattice Trust (SLT)** -- Lattice-native Byzantine detection without consensus. Under our evaluated harness, honest peers converged on identical trust state with up to 34% actively Byzantine participants (honest distance 49.5 vs Byzantine 165.0). No coordinator, no voting rounds; 34% is an empirical measurement, not a PBFT-style theoretical bound.
 
 **Resilience** -- 18 modules covering Sybil defence, longcon detection, epoch rotation, partition reconciliation, post-quantum signatures, and formal TLA+ specification (5/5 properties verified over 700 states).
 

--- a/docs/guides/federated-model-merging.md
+++ b/docs/guides/federated-model-merging.md
@@ -271,7 +271,7 @@ crdt-merge eliminates all of these. The merged model is a pure function of the c
 
 ## E4 Trust-Weighted Federation
 
-v0.9.5 adds the SLT Byzantine protocol to federated model merging, tolerating up to 34% Byzantine participants in a federation round. Trust scores propagate alongside model deltas, and a 10-node federation pipeline completes in 9.69ms end-to-end.
+v0.9.5 adds the SLT Byzantine-detection protocol to federated model merging. Under our evaluated harness, honest peers continued to converge on identical trust state with up to 34% actively Byzantine participants in a federation round (empirical measurement, not a PBFT-style theoretical bound). Trust scores propagate alongside model deltas, and a 10-node federation pipeline completes in 9.69ms end-to-end.
 
 ```python
 from crdt_merge.e4.integration.federation_bridge import TrustFederationRound

--- a/docs/guides/security-guide.md
+++ b/docs/guides/security-guide.md
@@ -530,7 +530,7 @@ compliance policies and generating audit reports.
 
 v0.9.5 extends the security architecture with the E4 trust layer, providing four interlocking defence mechanisms against Byzantine and Sybil attacks in distributed merge networks.
 
-**Byzantine defence.** The SLT (Statistical Lattice Trust) protocol tolerates up to 34% Byzantine participants in any merge federation. Participants whose behaviour diverges from the lattice consensus are automatically excluded, and the exclusion is cryptographically logged.
+**Byzantine defence.** The SLT (Symbiotic Lattice Trust) protocol is a lattice-native Byzantine-detection layer, not a PBFT-style consensus protocol. Under the evaluated harness, honest peers continued to converge on identical trust state with up to 34% actively Byzantine participants (empirical measurement, not a theoretical bound). Participants whose behaviour diverges from the lattice are automatically excluded via trust decay, and the exclusion is cryptographically logged.
 
 **Sybil detection.** The resilience subsystem detects coordinated identity fabrication by correlating trust evidence patterns across peers. New identities start at a baseline trust level and must accumulate genuine evidence before gaining merge influence.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crdt-merge"
-version = "0.9.7"
+version = "0.9.8"
 description = "Mathematically proven conflict-free merge for AI model weights, datasets, and agent memory with recursive trust-delta entanglement. Zero dependencies. Patent protected."
 readme = "README.md"
 license = {text = "BUSL-1.1"}


### PR DESCRIPTION
Tightens wording across README, CHANGELOG, and docs to match the more careful phrasing already in the published arXiv paper. No runtime changes; test suite pass count unchanged. The paper (paper/CRDT_Merge_ArXiv.tex) is untouched.

- 34% tolerance reframed as empirical SLT-harness measurement, not a PBFT-style theoretical bound. SLT is a Byzantine-detection layer, not a consensus protocol.
- Product-lattice wording: the product-of-join-semilattices construction is attributed to Birkhoff 1940; E4's contribution is Trust as a lattice dimension, not the product construction itself.
- E4-MASTER-ARCHITECTURE §VI renamed from "Entanglement Proof" to "Dependency Analysis (not a formal proof)".
- SLT acronym unified to Symbiotic (security-guide.md).
- 156/156 CRDT axiom trials relabelled with method context.
- Roadmap drift: Formal TLA+ spec moved from E4 Future Work to Shipped in 0.9.5. CRDT_ARCHITECTURE §11.3 and §11.4 marked SHIPPED (MergeStrategy/MergeSchema, merge_stream). §11.6 added as forward-reference to v0.9.9 alignment bounds.

Pre-existing failure in tests/test_accelerator_flight.py (test_init_defaults: host default 127.0.0.1 vs expected 0.0.0.0) is unrelated to this release; it reproduces on the pre-change tree.

## Description

<!-- Briefly describe your changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Other (please describe)

## Testing

- [ ] I have added/updated tests that prove my fix or feature works
- [ ] All existing tests pass

## Contributor License Agreement

- [ ] I have read and agree to the [Contributor License Agreement (CLA)](../CLA.md). By submitting this pull request, I grant Optitransfer the right to distribute my contribution under any license, including commercial licenses.
